### PR TITLE
Use UBI minimal instead of micro so we have proper OpenSSL packages

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -99,7 +99,7 @@ RUN if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "aarch64" ] || [ "$(una
         else ./build_product ocp4 --datastream-only; \
         fi
 
-FROM registry.redhat.io/ubi9/ubi-micro:latest
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 LABEL \
         io.k8s.display-name="Compliance Content" \


### PR DESCRIPTION
The ubi micro image doesn't have openssl packages and if we're using that we're failing the FIPS check since the resulting container image doesn't have the necessary openssl packages.

Let's use the minimal image which does have the necessary openssl packages and should pass the resulting check-payload check to release the operator.

