### PR TITLE
Use `rpms-signature-scan` task from tekton-catalog repo

### DIFF
--- a/.tekton/compliance-operator-content-release-1-7-pull-request.yaml
+++ b/.tekton/compliance-operator-content-release-1-7-pull-request.yaml
@@ -610,7 +610,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/compliance-operator-content-release-1-7-push.yaml
+++ b/.tekton/compliance-operator-content-release-1-7-push.yaml
@@ -611,7 +611,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION


#### Description:

- Use 'rpms-siganture-scan' task from tekton-catalog repo, the one from konflux-vanguard is not trusted by verify-conforma.

#### Rationale:
- We are failing `verify-conforma` during release.