### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for compliance-operator-content-release-1-7

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -110,7 +110,8 @@ LABEL \
         description="OpenSCAP content for the compliance-operator" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-compliance-content" \
+        name="compliance/openshift-compliance-content-rhel8" \
+        cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9" \
         com.redhat.component="openshift-compliance-content-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
