### PR TITLE
CMP-4216: Bump pipelines to release-1-9

### DIFF
--- a/.tekton/compliance-operator-content-release-1-9-pull-request.yaml
+++ b/.tekton/compliance-operator-content-release-1-9-pull-request.yaml
@@ -2,19 +2,19 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
-    build.appstudio.openshift.io/repo: https://github.com/ComplianceAsCode/content?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cac-content-fork?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.9"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: compliance-operator-dev
-    appstudio.openshift.io/component: compliance-operator-content-dev
+    appstudio.openshift.io/application: compliance-operator-release-1-9
+    appstudio.openshift.io/component: compliance-operator-content-release-1-9
     pipelines.appstudio.openshift.io/type: build
-  name: compliance-operator-content-dev-on-pull-request
+  name: compliance-operator-content-release-1-9-on-pull-request
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-release:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -625,7 +625,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-compliance-operator-content-dev
+    serviceAccountName: build-pipeline-compliance-operator-content-release-1-9
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/compliance-operator-content-release-1-9-push.yaml
+++ b/.tekton/compliance-operator-content-release-1-9-push.yaml
@@ -3,18 +3,18 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/build-nudge-files: "bundle-hack/update_csv.go"
-    build.appstudio.openshift.io/repo: https://github.com/ComplianceAsCode/content?rev={{revision}}
+    build.appstudio.openshift.io/repo: https://github.com/openshift/cac-content-fork?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.9"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: compliance-operator-dev
-    appstudio.openshift.io/component: compliance-operator-content-dev
+    appstudio.openshift.io/application: compliance-operator-release-1-9
+    appstudio.openshift.io/component: compliance-operator-content-release-1-9
     pipelines.appstudio.openshift.io/type: build
-  name: compliance-operator-content-dev-on-push
+  name: compliance-operator-content-release-1-9-on-push
   namespace: ocp-isc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:{{revision}}
+    value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-release:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -615,7 +615,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-compliance-operator-content-dev
+    serviceAccountName: build-pipeline-compliance-operator-content-release-1-9
   workspaces:
   - name: git-auth
     secret:

--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -103,9 +103,8 @@ LABEL \
         cpe="cpe:/a:redhat:openshift_compliance_operator:1::el9" \
         com.redhat.component="openshift-compliance-content-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
-        io.openshift.maintainer.component="Compliance Operator"
-        # Implement this using Konflux dynamic labels
-        # version=1.6.1-dev
+        io.openshift.maintainer.component="Compliance Operator" \
+        version=1.9.0
 
 WORKDIR /
 COPY --from=builder /go/src/github.com/ComplianceAsCode/content/LICENSE /licenses/LICENSE


### PR DESCRIPTION
#### Description:

- Rebrand Konflux pipelines to `compliance-operator-release-1-9`
- Bump image version to 1.9.0