### PR TITLE
CMP-4316: [release-1.9] Fix file_permissions/owner/groupowner_cni_conf for /etc/kubernetes/cni/net.d and runtime lock files

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -5,7 +5,12 @@ platform: ocp4-node
 
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'
+description: |-
+    {{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -31,6 +36,6 @@ ocil: |-
 template:
     name: file_groupowner
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -5,7 +5,12 @@ platform: ocp4-node
 
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
-description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'
+description: |-
+    {{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -31,6 +36,6 @@ ocil: |-
 template:
     name: file_owner
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         uid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -32,6 +36,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_not_s390x/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
     This rule is for architectures other than s390x.
 
 rationale: |-
@@ -33,6 +37,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf_s390x/rule.yml
@@ -7,6 +7,10 @@ title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
     {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
+    This also covers CNI configuration files under <tt>/etc/kubernetes/cni/net.d/</tt>,
+    which is the CRI-O network configuration directory (<tt>network_dir</tt>) used by
+    OpenShift; on newer releases <tt>/etc/cni/net.d/</tt> may be absent and the active
+    configuration lives only under <tt>/etc/kubernetes/cni/net.d/</tt>.
     This rule is for architectures on s390x.
 
 rationale: |-
@@ -33,6 +37,6 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/cni/net.d/.*$
+        filepath: ^/etc/(kubernetes/)?cni/net.d/.*\.(conf|conflist|json)$
         filemode: '0600'
         filepath_is_regex: "true"


### PR DESCRIPTION
Backport of ComplianceAsCode/content#14755

Fixes: [CMP-4323](https://redhat.atlassian.net/browse/CMP-4323)